### PR TITLE
Mock DGX Agent /health 추가

### DIFF
--- a/apps/dgx-agent/go.mod
+++ b/apps/dgx-agent/go.mod
@@ -1,0 +1,3 @@
+module dgx-agent
+
+go 1.25.3

--- a/apps/dgx-agent/main.go
+++ b/apps/dgx-agent/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+func healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"status": "ok",
+	})
+}
+
+func main() {
+	http.HandleFunc("/health", healthHandler)
+
+	log.Println("Mock DGX Agent listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
## What changed
- 일단 기본 서버 추가
- Get health 엔드포인트 구현
- JSON 응답 반환까지 완료

## How to test
-   apps/dgx-agent 에서 `go run main.go` 실행
- `curl http://localhost:8080/health` 호출
- `{"status":"ok"}` 응답 확인
