### PR TITLE
Mock DGX Agent 계정 작업 엔드포인트 및 request_id 멱등성 추가

### DIFF
--- a/apps/dgx-agent/main.go
+++ b/apps/dgx-agent/main.go
@@ -4,6 +4,24 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"sync"
+)
+
+type AccountRequest struct {
+	RequestID string `json:"request_id"`
+	Username  string `json:"username"`
+}
+
+type AccountResponse struct {
+	RequestID string `json:"request_id"`
+	Status    string `json:"status"`
+	Action    string `json:"action"`
+	Username  string `json:"username"`
+}
+
+var (
+	requestStore = make(map[string]AccountResponse)
+	mu           sync.Mutex
 )
 
 func healthHandler(w http.ResponseWriter, r *http.Request) {
@@ -15,8 +33,76 @@ func healthHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func handleAccountAction(action string, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req AccountRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json body", http.StatusBadRequest)
+		return
+	}
+
+	if req.RequestID == "" {
+		http.Error(w, "request_id is required", http.StatusBadRequest)
+		return
+	}
+
+	if req.Username == "" {
+		http.Error(w, "username is required", http.StatusBadRequest)
+		return
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// 같은 request_id가 이미 있으면 예전 결과 그대로 반환함
+	if saved, exists := requestStore[req.RequestID]; exists {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(saved)
+		return
+	}
+
+	// 처음 들어온 request_id면 새 결과 생성함
+	resp := AccountResponse{
+		RequestID: req.RequestID,
+		Status:    "success",
+		Action:    action,
+		Username:  req.Username,
+	}
+
+	requestStore[req.RequestID] = resp
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func createHandler(w http.ResponseWriter, r *http.Request) {
+	handleAccountAction("create", w, r)
+}
+
+func disableHandler(w http.ResponseWriter, r *http.Request) {
+	handleAccountAction("disable", w, r)
+}
+
+func archiveHandler(w http.ResponseWriter, r *http.Request) {
+	handleAccountAction("archive", w, r)
+}
+
+func purgeHandler(w http.ResponseWriter, r *http.Request) {
+	handleAccountAction("purge", w, r)
+}
+
 func main() {
 	http.HandleFunc("/health", healthHandler)
+	http.HandleFunc("/accounts/create", createHandler)
+	http.HandleFunc("/accounts/disable", disableHandler)
+	http.HandleFunc("/accounts/archive", archiveHandler)
+	http.HandleFunc("/accounts/purge", purgeHandler)
 
 	log.Println("Mock DGX Agent listening on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))


### PR DESCRIPTION
## What changed
- Mock 환경에서도 계정 관련 API 흐름을 테스트할 수 있도록 기본 동작 추가,
- Mock DGX Agent에 계정 작업용 엔드포인트를 추가했고,
- POST /accounts/create 구현,
- POST /accounts/disable 구현,
- POST /accounts/archive 구현.
- POST /accounts/purge 구현
- request_id 기반 멱등성 흉내 추가도 포함
- 같은 request_id 재호출 시 기존 응답 반환하도록 처리함


## How to test
1. apps/dgx-agent 에서 `go run main.go` 실행하기
2. `curl http://localhost:8080/health` 로 서버 상태 확인시켜줌
3. 아래 요청들을 각 엔드 포인트에 응답 확인

curl -X POST http://localhost:8080/accounts/create \
  -H "Content-Type: application/json" \
  -d '{"request_id":"req-1","username":"적고 싶은 이름"}'

curl -X POST http://localhost:8080/accounts/disable \
  -H "Content-Type: application/json" \
  -d '{"request_id":"req-2","username":"적고 싶은 이름"}'

curl -X POST http://localhost:8080/accounts/archive \
  -H "Content-Type: application/json" \
  -d '{"request_id":"req-3","username":"적고 싶은 이름"}'

curl -X POST http://localhost:8080/accounts/purge \
  -H "Content-Type: application/json" \
  -d '{"request_id":"req-4","username":"적고 싶은 이름"}'
